### PR TITLE
Allow multiple projects for a single subcommand invocation

### DIFF
--- a/project_generator/commands/build.py
+++ b/project_generator/commands/build.py
@@ -23,22 +23,24 @@ help = 'Build a project'
 
 def run(args):
     # Export if we know how, otherwise return
+    combined_projects = args.projects + args.project or ['']
+    kwargs = split_options(args.options)
     generator = Generator(args.file)
     any_build_failed = False
     any_export_failed = False
-    for project in generator.generate(args.project):
-        clean_failed = False
-        if args.clean and project.clean(args.tool) == -1:
-            clean_failed = True # So we don't attempt to generate or build this project.
-            any_build_failed = True
-        if not clean_failed:
-            if project.generate(args.tool, args.copy) == -1:
-                any_export_failed = True
-            kwargs = split_options(args.options)
-            if project.build(args.tool, jobs=args.jobs, **kwargs) == -1:
+    for project_name in combined_projects:
+        for project in generator.generate(project_name):
+            clean_failed = False
+            if args.clean and project.clean(args.tool) == -1:
+                clean_failed = True # So we don't attempt to generate or build this project.
                 any_build_failed = True
-        if args.stop_on_failure and (any_build_failed or any_export_failed):
-            break
+            if not clean_failed:
+                if project.generate(args.tool, args.copy) == -1:
+                    any_export_failed = True
+                if project.build(args.tool, jobs=args.jobs, **kwargs) == -1:
+                    any_build_failed = True
+            if args.stop_on_failure and (any_build_failed or any_export_failed):
+                break
 
     if any_build_failed or any_export_failed:
         return -1
@@ -54,7 +56,7 @@ def setup(subparser):
         "-f", "--file", help="YAML projects file", default='projects.yaml',
         type=argparse_filestring_type)
     subparser.add_argument(
-        "-p", "--project", help="Name of the project to build", default = '')
+        "-p", "--project", dest="projects", action='append', default=[], help="Name of the project to build")
     subparser.add_argument(
         "-t", "--tool", help="Build a project files for provided tool",
         type=argparse_string_type(str.lower, False), choices=list(ToolsSupported.TOOLS_DICT.keys()) + list(ToolsSupported.TOOLS_ALIAS.keys()))
@@ -69,3 +71,5 @@ def setup(subparser):
     subparser.add_argument(
         "-j", "--jobs", action="store", type=int, default=1,
         help="Number of concurrent build jobs (not supported by all tools)")
+    subparser.add_argument("project", nargs='*',
+                        help="Specify projects to be generated and built")

--- a/project_generator/commands/clean.py
+++ b/project_generator/commands/clean.py
@@ -22,9 +22,11 @@ help = 'Clean generated projects'
 
 
 def run(args):
+    combined_projects = args.projects + args.project or ['']
     generator = Generator(args.file)
-    for project in generator.generate(args.project):
-        project.clean(args.tool)
+    for project_name in (combined_projects):
+        for project in generator.generate(project_name):
+            project.clean(args.tool)
     return 0
 
 def setup(subparser):
@@ -33,7 +35,10 @@ def setup(subparser):
     subparser.add_argument('-q', dest='quietness', action='count', default=0,
                         help='Decrease the verbosity of the output (repeat for more verbose output)')
     subparser.add_argument("-f", "--file", help="YAML projects file", default='projects.yaml', type=argparse_filestring_type)
-    subparser.add_argument("-p", "--project", required = True, help="Specify which project to be removed")
+    subparser.add_argument("-p", "--project", dest="projects", action='append', default=[],
+                        help="Specify which project to be removed")
     subparser.add_argument(
-        "-t", "--tool", help="Clean project files for this tool",
+        "-t", "--tool", help="Clean project files for this tool", required=True,
         type=argparse_string_type(str.lower, False), choices=list(ToolsSupported.TOOLS_DICT.keys()) + list(ToolsSupported.TOOLS_ALIAS.keys()))
+    subparser.add_argument("project", nargs='*',
+                        help="Specify projects to be removed")


### PR DESCRIPTION
Allow multiple projects to be specified for `build`, `generate`, and `clean` subcommands.

- More than one `-p`/`--project` argument is allowed.
- Passing one or more project names as positional arguments is allowed.